### PR TITLE
EnableGatewayMonitor parameters

### DIFF
--- a/src/main/java/uk/gov/ons/fwmt/census/events/utils/GatewayEventMonitor.java
+++ b/src/main/java/uk/gov/ons/fwmt/census/events/utils/GatewayEventMonitor.java
@@ -45,9 +45,13 @@ public class GatewayEventMonitor {
   }
 
   public void enableEventMonitor() throws IOException, TimeoutException {
+    enableEventMonitor("localhost");
+  }
+
+  public void enableEventMonitor(String rabbitLocation) throws IOException, TimeoutException {
     gatewayEventMap = new HashMap<>();
     ConnectionFactory factory = new ConnectionFactory();
-    factory.setHost("localhost");
+    factory.setHost(rabbitLocation);
     connection = factory.newConnection();
     channel = connection.createChannel();
 


### PR DESCRIPTION
can now take in a variables of rabbit host or left with no parameter for localhost